### PR TITLE
Jira-rest-java-client-core  has been upgraded from 5.2.2 to 5.2.4 as …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,10 +193,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+       <!--====== upgraded from 5.2.2 tp 5.2.4 =============-->
         <dependency>
             <groupId>com.atlassian.jira</groupId>
             <artifactId>jira-rest-java-client-core</artifactId>
-            <version>5.2.2</version>
+            <version>5.2.4</version>
         </dependency>
         <dependency>
             <groupId>io.atlassian.fugue</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -193,12 +193,16 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+
        <!--====== upgraded from 5.2.2 tp 5.2.4 =============-->
         <dependency>
             <groupId>com.atlassian.jira</groupId>
             <artifactId>jira-rest-java-client-core</artifactId>
             <version>5.2.4</version>
         </dependency>
+
+
         <dependency>
             <groupId>io.atlassian.fugue</groupId>
             <artifactId>fugue</artifactId>


### PR DESCRIPTION
Jira-rest-java-client-core has been upgraded from 5.2.2 to 5.2.4 as the current higher major version in the maven repository, as the current spring beans version (5.3.6 ) appears to be already higher than the targeted upgrade of 5.2.20.Release.