### PR TITLE
Spring beans downgraded from 5.3.18 to version 5.2.20 just for check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,14 +194,12 @@
             </exclusions>
         </dependency>
 
-
        <!--====== upgraded from 5.2.2 tp 5.2.4 =============-->
         <dependency>
             <groupId>com.atlassian.jira</groupId>
             <artifactId>jira-rest-java-client-core</artifactId>
             <version>5.2.4</version>
         </dependency>
-
 
         <dependency>
             <groupId>io.atlassian.fugue</groupId>


### PR DESCRIPTION
Spring beans were downgraded from 5.3.18 to version 5.2.20 just for a check