### PR TITLE
Use Authentication Bearer with Personal Access Token

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     </repositories>
 
     <properties>
-        <ready-api-version>3.49.0</ready-api-version>
+        <ready-api-version>3.51.0</ready-api-version>
         <log4j-core-version>2.17.1</log4j-core-version>
         <guice.version>4.2.2</guice.version>
         <xmlbeans.version>3.1.2-sb-fixed</xmlbeans.version>
@@ -58,6 +58,20 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <!--plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin-->
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>2.4</version>
@@ -66,6 +80,15 @@
                         <descriptor>src/assembly/dist-assembly.xml</descriptor>
                     </descriptors>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id> <!-- this is used for inheritance merges -->
+                        <phase>package</phase> <!-- bind to the packaging phase -->
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
@@ -184,7 +207,7 @@
         <dependency>
             <groupId>com.atlassian.jira</groupId>
             <artifactId>jira-rest-java-client-api</artifactId>
-            <version>5.2.4</version>
+            <version>5.2.6</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>
@@ -197,7 +220,7 @@
         <dependency>
             <groupId>com.atlassian.jira</groupId>
             <artifactId>jira-rest-java-client-core</artifactId>
-            <version>5.2.4</version>
+            <version>5.2.6</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/smartbear/ready/plugin/jira/factories/JiraPrefsFactory.java
+++ b/src/main/java/com/smartbear/ready/plugin/jira/factories/JiraPrefsFactory.java
@@ -20,13 +20,13 @@ import java.awt.event.FocusListener;
 @PluginPrefs
 public class JiraPrefsFactory implements Prefs {
     public static final String BUG_TRACKER_LOGIN_LABEL = "Email or username:";
-    public static final String BUG_TRACKER_PASSWORD = "API Token or Password:";
-    public static final String BUG_TRACKER_LOGIN_DESCRIPTION = "Your JIRA user account";
-    public static final String BUG_TRACKER_LOGIN_IN_FIELD_DESCRIPTION = "Your JIRA user account";
-    public static final String BUG_TRACKER_PASSWORD_DESCRIPTION = "The password for logging in";
+    public static final String BUG_TRACKER_LOGIN_DESCRIPTION = "Your profile's e-mail (JIRA Cloud) or your profile's user name (JIRA Server) or empty when using a Private Access Token (PAT)." ;
+    public static final String BUG_TRACKER_LOGIN_IN_FIELD_DESCRIPTION = BUG_TRACKER_LOGIN_DESCRIPTION;
+    public static final String BUG_TRACKER_PASSWORD = "Password or Personal Access Token (PAT):";
+    public static final String BUG_TRACKER_PASSWORD_DESCRIPTION = "This your password or a Personal Access Token (PAT).";
     public static final String BUG_TRACKER_URL = "JIRA server URL:";
-    public static final String BUG_TRACKER_URL_DESCRIPTION = "The URL of your JIRA instance, for instance, https://mycompany.atlassian.net";
-    public static final String BUG_TRACKER_URL_IN_FIELD_DESCRIPTION = "The URL of your JIRA instance (https://...)";
+    public static final String BUG_TRACKER_URL_IN_FIELD_DESCRIPTION = "The URL of your JIRA instance (without the /rest/api/* part)";
+    public static final String BUG_TRACKER_URL_DESCRIPTION = BUG_TRACKER_URL_IN_FIELD_DESCRIPTION + ", for instance, https://mycompany.atlassian.net or https://mycompany.net/jira";
     public static final String JIRA_PREFS_TITLE = "JIRA";
     public static final String SKIP_RELEASED_VERSIONS = "Hide released versions:";
     public static final String SKIP_RELEASED_VERSIONS_DESCRIPTION = "Do not show released versions for \"Fixed Version/s\" field";

--- a/src/main/java/com/smartbear/ready/plugin/jira/impl/BearerHttpAuthenticationHandler.java
+++ b/src/main/java/com/smartbear/ready/plugin/jira/impl/BearerHttpAuthenticationHandler.java
@@ -1,0 +1,19 @@
+package com.smartbear.ready.plugin.jira.impl;
+
+import com.atlassian.httpclient.api.Request;
+import com.atlassian.jira.rest.client.api.AuthenticationHandler;
+
+public class BearerHttpAuthenticationHandler implements AuthenticationHandler {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private final String token;
+
+    public BearerHttpAuthenticationHandler(final String token) {
+        this.token = token;
+    }
+
+    @Override
+    public void configure(Request.Builder builder) {
+        builder.setHeader(AUTHORIZATION_HEADER, "Bearer " + token);
+    }
+}

--- a/src/main/java/com/smartbear/ready/plugin/jira/impl/JiraProvider.java
+++ b/src/main/java/com/smartbear/ready/plugin/jira/impl/JiraProvider.java
@@ -117,7 +117,13 @@ public class JiraProvider implements SimpleBugTrackerProvider {
         try {
             String url = bugTrackerSettings.getUrl();
             URI uri = new URI(url);
-            restClient = factory.createWithBasicHttpAuthentication(uri, bugTrackerSettings.getLogin(), bugTrackerSettings.getPassword());
+            if (bugTrackerSettings.getLogin() != null && ! bugTrackerSettings.getLogin().isEmpty() && ! bugTrackerSettings.getLogin().isBlank() ) {
+                restClient = factory.createWithBasicHttpAuthentication(uri, bugTrackerSettings.getLogin(), bugTrackerSettings.getPassword());
+            } else {
+                BearerHttpAuthenticationHandler handler = new BearerHttpAuthenticationHandler(bugTrackerSettings.getPassword());
+                restClient = factory.create(uri, handler);
+            }
+
             logger.info("[JiraProvider].[JiraProvider] restClient", restClient.toString());
         } catch (URISyntaxException e) {
             logger.error(BUG_TRACKER_URI_IS_INCORRECT);
@@ -591,7 +597,7 @@ public class JiraProvider implements SimpleBugTrackerProvider {
     public boolean settingsComplete(BugTrackerSettings settings) {
         return !(settings == null ||
                 StringUtils.isNullOrEmpty(settings.getUrl()) ||
-                StringUtils.isNullOrEmpty(settings.getLogin()) ||
+                //StringUtils.isNullOrEmpty(settings.getLogin()) ||
                 StringUtils.isNullOrEmpty(settings.getPassword()));
     }
 


### PR DESCRIPTION
- Use Authentication Bearer when an Personal Access Token is used without login.
- Bump ready-api-* to 3.51.0
- Bump jira-rest-java-client-* to 5.2.6